### PR TITLE
Compare refName instead of references

### DIFF
--- a/src/test/java/org/arend/typechecking/subexpr/CorrespondedSubExprTest.java
+++ b/src/test/java/org/arend/typechecking/subexpr/CorrespondedSubExprTest.java
@@ -396,6 +396,6 @@ public class CorrespondedSubExprTest extends TypeCheckingTestCase {
     Concrete.Expression c = concrete.getStatements().get(1).implementation;
     Pair<Expression, Concrete.Expression> accept = concrete.accept(new CorrespondedSubExprVisitor(c), core);
     assertNotNull(accept);
-    assertEquals("x", accept.proj1.toString());
+    assertEquals(c.toString(), accept.proj1.toString());
   }
 }


### PR DESCRIPTION
I'm comparing names instead of refs because the subexpr refs are TCWrapper refs while the big AST refs are LocatedRefs. They refer to the same definition, the names are the same but they are different references, which causes mismatches of expressions.