### PR TITLE
Fix incorrect order of clauses in pattern-matching

### DIFF
--- a/base/src/main/java/org/arend/typechecking/patternmatching/ElimTypechecking.java
+++ b/base/src/main/java/org/arend/typechecking/patternmatching/ElimTypechecking.java
@@ -340,10 +340,10 @@ public class ElimTypechecking {
       List<List<ExpressionPattern>> totalResult = new ArrayList<>();
       if (conCalls.isEmpty()) {
         List<ExpressionPattern> patterns = new ArrayList<>();
-        patterns.add(EmptyPattern.INSTANCE);
-        for (i++; i < eliminatedParameters.size(); i++) {
-          patterns.add(new BindingPattern(eliminatedParameters.get(i)));
+        for (int j = eliminatedParameters.size() - 1; j > i; j--) {
+          patterns.add(new BindingPattern(eliminatedParameters.get(j)));
         }
+        patterns.add(EmptyPattern.INSTANCE);
         totalResult.add(patterns);
       } else {
         boolean firstHasEmpty = false;


### PR DESCRIPTION
"Implement missing clauses" fix inserts empty patterns in the wrong order.

You can find a test for this change [here](https://github.com/JetBrains/intellij-arend/pull/215).