### PR TITLE
Extract base type from GoalError

### DIFF
--- a/base/src/main/java/org/arend/typechecking/error/local/GoalDataHolder.java
+++ b/base/src/main/java/org/arend/typechecking/error/local/GoalDataHolder.java
@@ -1,0 +1,91 @@
+package org.arend.typechecking.error.local;
+
+import org.arend.core.context.binding.Binding;
+import org.arend.core.context.binding.EvaluatingBinding;
+import org.arend.core.expr.Expression;
+import org.arend.core.subst.ExprSubstitution;
+import org.arend.ext.concrete.ConcreteSourceNode;
+import org.arend.ext.error.TypecheckingError;
+import org.arend.ext.prettyprinting.PrettyPrinterConfig;
+import org.arend.ext.prettyprinting.doc.Doc;
+import org.arend.naming.reference.GeneratedLocalReferable;
+import org.arend.naming.reference.LocalReferable;
+import org.arend.naming.reference.Referable;
+import org.arend.typechecking.TypecheckingContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+import static org.arend.ext.prettyprinting.doc.DocFactory.*;
+
+public class GoalDataHolder extends TypecheckingError {
+    public final TypecheckingContext typecheckingContext;
+    public final Map<Binding, Expression> bindingTypes;
+    public final Expression expectedType;
+
+    private final ExprSubstitution substitution;
+
+    public GoalDataHolder(@NotNull Level level,
+                          @NotNull String message,
+                          @Nullable ConcreteSourceNode cause,
+                          @Nullable TypecheckingContext typecheckingContext,
+                          @NotNull Map<Binding, Expression> bindingTypes,
+                          @Nullable Expression expectedType) {
+        super(level, message, cause);
+        this.typecheckingContext = typecheckingContext;
+        this.bindingTypes = bindingTypes;
+        this.substitution = calculateSubstitution(typecheckingContext);
+        this.expectedType = expectedType == null ? null : expectedType.subst(substitution);
+    }
+
+    @NotNull
+    private static ExprSubstitution calculateSubstitution(TypecheckingContext typecheckingContext) {
+        ExprSubstitution substitution = new ExprSubstitution();
+        if (typecheckingContext != null) {
+            for (Iterator<Map.Entry<Referable, Binding>> iterator = typecheckingContext.localContext.entrySet().iterator(); iterator.hasNext(); ) {
+                Map.Entry<Referable, Binding> entry = iterator.next();
+                if (entry.getKey() instanceof GeneratedLocalReferable && entry.getValue() instanceof EvaluatingBinding) {
+                    substitution.add(entry.getValue(), ((EvaluatingBinding) entry.getValue()).getExpression());
+                    iterator.remove();
+                }
+            }
+        }
+        return substitution;
+    }
+
+    @Override
+    public Doc getBodyDoc(PrettyPrinterConfig ppConfig) {
+        Doc expectedDoc = getExpectedDoc(ppConfig);
+        Doc contextDoc = getContextDoc(ppConfig);
+        return vList(expectedDoc, contextDoc);
+    }
+
+    @NotNull
+    protected Doc getExpectedDoc(PrettyPrinterConfig ppConfig) {
+        return expectedType == null ? nullDoc() : hang(text("Expected type:"), expectedType.prettyPrint(ppConfig));
+    }
+
+    @NotNull
+    protected Doc getContextDoc(PrettyPrinterConfig ppConfig) {
+        Map<Referable, Binding> context = typecheckingContext == null ? Collections.emptyMap() : typecheckingContext.localContext;
+        if (!context.isEmpty()) {
+            List<Doc> contextDocs = new ArrayList<>(context.size());
+            for (Map.Entry<Referable, Binding> entry : context.entrySet()) {
+                if (!entry.getValue().isHidden() && (!(entry.getKey() instanceof LocalReferable) || !((LocalReferable) entry.getKey()).isHidden())) {
+                    Expression type = bindingTypes.get(entry.getValue());
+                    if (type == null) type = entry.getValue().getTypeExpr();
+                    if (type != null) type = type.subst(substitution);
+                    contextDocs.add(hang(hList(entry.getKey() == null ? text("_") : refDoc(entry.getKey()), text(" :")), type == null ? text("{?}") : termDoc(type, ppConfig)));
+                }
+            }
+            return contextDocs.isEmpty() ? nullDoc() : hang(text("Context:"), vList(contextDocs));
+        }
+        return nullDoc();
+    }
+
+    @Override
+    public boolean hasExpressions() {
+        return true;
+    }
+}

--- a/base/src/main/java/org/arend/typechecking/error/local/GoalError.java
+++ b/base/src/main/java/org/arend/typechecking/error/local/GoalError.java
@@ -1,60 +1,42 @@
 package org.arend.typechecking.error.local;
 
 import org.arend.core.context.binding.Binding;
-import org.arend.core.context.binding.EvaluatingBinding;
 import org.arend.core.expr.Expression;
-import org.arend.core.subst.ExprSubstitution;
 import org.arend.ext.error.GeneralError;
-import org.arend.ext.error.TypecheckingError;
 import org.arend.ext.prettyprinting.PrettyPrinterConfig;
 import org.arend.ext.prettyprinting.doc.Doc;
 import org.arend.ext.typechecking.GoalSolver;
-import org.arend.naming.reference.GeneratedLocalReferable;
-import org.arend.naming.reference.LocalReferable;
-import org.arend.naming.reference.Referable;
 import org.arend.term.concrete.Concrete;
 import org.arend.typechecking.TypecheckingContext;
 import org.arend.typechecking.patternmatching.Condition;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.arend.ext.prettyprinting.doc.DocFactory.*;
 
-public class GoalError extends TypecheckingError {
-  public final TypecheckingContext typecheckingContext;
-  public final Map<Binding, Expression> bindingTypes;
-  public final Expression expectedType;
+public class GoalError extends GoalDataHolder {
   public final Concrete.Expression result;
   public final List<GeneralError> errors;
   public final GoalSolver goalSolver;
-  private final ExprSubstitution substitution;
+
   private List<Condition> myConditions = Collections.emptyList();
 
-  public GoalError(TypecheckingContext typecheckingContext, Map<Binding, Expression> bindingTypes, Expression expectedType, Concrete.Expression result, List<GeneralError> errors, GoalSolver goalSolver, Concrete.GoalExpression expression) {
-    super(Level.GOAL, "Goal" + (expression.getName() == null ? "" : " " + expression.getName()), expression);
-    this.typecheckingContext = typecheckingContext;
-    this.bindingTypes = bindingTypes;
+  public GoalError(TypecheckingContext typecheckingContext,
+                   Map<Binding, Expression> bindingTypes,
+                   Expression expectedType,
+                   Concrete.Expression result,
+                   List<GeneralError> errors,
+                   GoalSolver goalSolver,
+                   Concrete.GoalExpression expression) {
+    super(Level.GOAL, "Goal" + (expression.getName() == null ? "" : " " + expression.getName()), expression,
+            typecheckingContext, bindingTypes, expectedType);
     this.result = result;
     this.errors = errors;
     this.goalSolver = goalSolver;
-    substitution = calculateSubstitution(typecheckingContext);
-    this.expectedType = expectedType == null ? null : expectedType.subst(substitution);
-  }
-
-  @NotNull
-  private static ExprSubstitution calculateSubstitution(TypecheckingContext typecheckingContext) {
-    ExprSubstitution substitution = new ExprSubstitution();
-    if (typecheckingContext != null) {
-      for (Iterator<Map.Entry<Referable, Binding>> iterator = typecheckingContext.localContext.entrySet().iterator(); iterator.hasNext(); ) {
-        Map.Entry<Referable, Binding> entry = iterator.next();
-        if (entry.getKey() instanceof GeneratedLocalReferable && entry.getValue() instanceof EvaluatingBinding) {
-          substitution.add(entry.getValue(), ((EvaluatingBinding) entry.getValue()).getExpression());
-          iterator.remove();
-        }
-      }
-    }
-    return substitution;
   }
 
   @Override
@@ -69,29 +51,6 @@ public class GoalError extends TypecheckingError {
     Doc conditionsDoc = getConditionsDoc(ppConfig);
     Doc errorsDoc = getErrorsDoc(ppConfig);
     return vList(expectedDoc, contextDoc, conditionsDoc, errorsDoc);
-  }
-
-  @NotNull
-  private Doc getExpectedDoc(PrettyPrinterConfig ppConfig) {
-    return expectedType == null ? nullDoc() : hang(text("Expected type:"), expectedType.prettyPrint(ppConfig));
-  }
-
-  @NotNull
-  private Doc getContextDoc(PrettyPrinterConfig ppConfig) {
-    Map<Referable, Binding> context = typecheckingContext == null ? Collections.emptyMap() : typecheckingContext.localContext;
-    if (!context.isEmpty()) {
-      List<Doc> contextDocs = new ArrayList<>(context.size());
-      for (Map.Entry<Referable, Binding> entry : context.entrySet()) {
-        if (!entry.getValue().isHidden() && (!(entry.getKey() instanceof LocalReferable) || !((LocalReferable) entry.getKey()).isHidden())) {
-          Expression type = bindingTypes.get(entry.getValue());
-          if (type == null) type = entry.getValue().getTypeExpr();
-          if (type != null) type = type.subst(substitution);
-          contextDocs.add(hang(hList(entry.getKey() == null ? text("_") : refDoc(entry.getKey()), text(" :")), type == null ? text("{?}") : termDoc(type, ppConfig)));
-        }
-      }
-      return contextDocs.isEmpty() ? nullDoc() : hang(text("Context:"), vList(contextDocs));
-    }
-    return nullDoc();
   }
 
   @NotNull
@@ -116,11 +75,6 @@ public class GoalError extends TypecheckingError {
       return hang(text("Errors:"), vList(errorsDocs));
     }
     return nullDoc();
-  }
-
-  @Override
-  public boolean hasExpressions() {
-    return true;
   }
 
   public void addCondition(Condition condition) {

--- a/base/src/main/java/org/arend/typechecking/visitor/CheckTypeVisitor.java
+++ b/base/src/main/java/org/arend/typechecking/visitor/CheckTypeVisitor.java
@@ -3481,7 +3481,7 @@ public class CheckTypeVisitor extends UserDataHolderImpl implements ConcreteExpr
     return new TypecheckingResult(result, expectedType != null && !(expectedType instanceof Type && ((Type) expectedType).isOmega()) ? expectedType : result);
   }
 
-  private Map<Binding, Expression> getBindingTypes() {
+  protected Map<Binding, Expression> getBindingTypes() {
     Map<Binding, Expression> result = new HashMap<>();
     for (Binding binding : context.values()) {
       if (binding instanceof TypedHaveClause || binding instanceof TypedLetClause) {

--- a/base/src/main/java/org/arend/typechecking/visitor/DumbTypechecker.java
+++ b/base/src/main/java/org/arend/typechecking/visitor/DumbTypechecker.java
@@ -88,7 +88,7 @@ public class DumbTypechecker extends VoidConcreteVisitor<Void, Void> {
 
   @Override
   public Void visitGoal(Concrete.GoalExpression expr, Void params) {
-    myTypechecker.errorReporter.report(new GoalError(null, null, null, null, Collections.emptyList(), null, expr));
+    myTypechecker.errorReporter.report(new GoalError(null, Collections.emptyMap(), null, null, Collections.emptyList(), null, expr));
     return null;
   }
 


### PR DESCRIPTION
This change is needed to implement the tracer in the `intellij-arend`. I extract `GoalDataHolder` as a base type of the `GoalError` and use that base type in the tracing typechecker.