### PR TITLE
Introduce tuning of pretty printer

### DIFF
--- a/api/src/main/java/org/arend/ext/prettyprinting/PrettyPrinterConfig.java
+++ b/api/src/main/java/org/arend/ext/prettyprinting/PrettyPrinterConfig.java
@@ -39,8 +39,8 @@ public interface PrettyPrinterConfig {
    * then it will be printed with two additional implicit arguments.
    */
   default int getVerboseLevel(@NotNull CoreExpression expression) {
-        return 0;
-    }
+    return 0;
+  }
   default int getVerboseLevel(@NotNull CoreParameter parameter) {
     return 0;
   }

--- a/api/src/main/java/org/arend/ext/prettyprinting/PrettyPrinterConfig.java
+++ b/api/src/main/java/org/arend/ext/prettyprinting/PrettyPrinterConfig.java
@@ -1,5 +1,6 @@
 package org.arend.ext.prettyprinting;
 
+import org.arend.ext.core.expr.CoreExpression;
 import org.arend.ext.core.ops.NormalizationMode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,6 +30,16 @@ public interface PrettyPrinterConfig {
   default @Nullable DefinitionRenamer getDefinitionRenamer() {
     return null;
   }
+
+  /**
+   * If an expression has a positive verbose level, then it is printed with additional information.
+   * The kind of the information depends on runtime class of the expression.
+   * For example, if a {@link org.arend.ext.core.expr.CoreAppExpression} has verbose level = 2,
+   * then it will be printed with two additional implicit arguments.
+   */
+  default int getVerboseLevel(@NotNull CoreExpression expression) {
+        return 0;
+    }
 
   PrettyPrinterConfig DEFAULT = new PrettyPrinterConfig() {};
 }

--- a/api/src/main/java/org/arend/ext/prettyprinting/PrettyPrinterConfig.java
+++ b/api/src/main/java/org/arend/ext/prettyprinting/PrettyPrinterConfig.java
@@ -1,5 +1,6 @@
 package org.arend.ext.prettyprinting;
 
+import org.arend.ext.core.context.CoreParameter;
 import org.arend.ext.core.expr.CoreExpression;
 import org.arend.ext.core.ops.NormalizationMode;
 import org.jetbrains.annotations.NotNull;
@@ -40,6 +41,9 @@ public interface PrettyPrinterConfig {
   default int getVerboseLevel(@NotNull CoreExpression expression) {
         return 0;
     }
+  default int getVerboseLevel(@NotNull CoreParameter parameter) {
+    return 0;
+  }
 
   PrettyPrinterConfig DEFAULT = new PrettyPrinterConfig() {};
 }

--- a/base/src/main/java/org/arend/term/concrete/ConcreteExpressionFactory.java
+++ b/base/src/main/java/org/arend/term/concrete/ConcreteExpressionFactory.java
@@ -118,6 +118,10 @@ public class ConcreteExpressionFactory {
     return new Concrete.NameParameter(null, true, referable);
   }
 
+  public static Concrete.NameParameter cName(boolean explicit, Referable referable) {
+    return new Concrete.NameParameter(null, explicit, referable);
+  }
+
   public static Concrete.NameParameter cName(Object data, boolean explicit, Referable referable) {
     return new Concrete.NameParameter(data, explicit, referable);
   }
@@ -138,6 +142,10 @@ public class ConcreteExpressionFactory {
     return new Concrete.TelescopeParameter(null, explicit, referableList, type);
   }
 
+  public static Concrete.TelescopeParameter cTele(Object data, boolean explicit, List<? extends Referable> referableList, Concrete.Expression type) {
+    return new Concrete.TelescopeParameter(data, explicit, referableList, type);
+  }
+
   public static Concrete.PiExpression cPi(Concrete.Expression domain, Concrete.Expression codomain) {
     return new Concrete.PiExpression(null, ctypeArgs(cTypeArg(domain)), codomain);
   }
@@ -147,7 +155,7 @@ public class ConcreteExpressionFactory {
   }
 
   public static Concrete.PiExpression cPi(boolean explicit, Referable var, Concrete.Expression domain, Concrete.Expression codomain) {
-    return new Concrete.PiExpression(null, ctypeArgs(cTele(explicit, cvars(var), domain)), codomain);
+    return new Concrete.PiExpression(null, ctypeArgs(cTele(null, explicit, cvars(var), domain)), codomain);
   }
 
   public static Concrete.PiExpression cPi(Referable var, Concrete.Expression domain, Concrete.Expression codomain) {

--- a/base/src/main/java/org/arend/term/concrete/ConcreteExpressionFactory.java
+++ b/base/src/main/java/org/arend/term/concrete/ConcreteExpressionFactory.java
@@ -28,10 +28,10 @@ public class ConcreteExpressionFactory {
     return new Concrete.ReferenceExpression(null, referable);
   }
 
-  public static Concrete.ReferenceExpression cVar(LongName longName, Referable referable) {
+  public static Concrete.ReferenceExpression cVar(Object data, LongName longName, Referable referable) {
     return longName == null
-      ? new Concrete.ReferenceExpression(null, referable)
-      : new Concrete.LongReferenceExpression(null, null, longName, referable);
+      ? new Concrete.ReferenceExpression(data, referable)
+      : new Concrete.LongReferenceExpression(data, null, longName, referable);
   }
 
   public static Concrete.ReferenceExpression cVar(Concrete.ReferenceExpression qualifierExpression, LongName longName, Referable referable) {
@@ -40,10 +40,10 @@ public class ConcreteExpressionFactory {
             : new Concrete.LongReferenceExpression(null, qualifierExpression, longName, referable);
   }
 
-  public static Concrete.ReferenceExpression cDefCall(LongName longName, Referable referable, List<Concrete.LevelExpression> pLevels, List<Concrete.LevelExpression> hLevels) {
+  public static Concrete.ReferenceExpression cDefCall(Object data, LongName longName, Referable referable, List<Concrete.LevelExpression> pLevels, List<Concrete.LevelExpression> hLevels) {
     return longName == null
-      ? new Concrete.ReferenceExpression(null, referable, pLevels, hLevels)
-      : new Concrete.LongReferenceExpression(null, null, longName, referable, pLevels, hLevels);
+      ? new Concrete.ReferenceExpression(data, referable, pLevels, hLevels)
+      : new Concrete.LongReferenceExpression(data, null, longName, referable, pLevels, hLevels);
   }
 
   public static Concrete.ClassExtExpression cClassExt(Concrete.Expression expr, List<Concrete.ClassFieldImpl> definitions) {

--- a/base/src/main/java/org/arend/term/concrete/ConcreteExpressionFactory.java
+++ b/base/src/main/java/org/arend/term/concrete/ConcreteExpressionFactory.java
@@ -118,8 +118,8 @@ public class ConcreteExpressionFactory {
     return new Concrete.NameParameter(null, true, referable);
   }
 
-  public static Concrete.NameParameter cName(boolean explicit, Referable referable) {
-    return new Concrete.NameParameter(null, explicit, referable);
+  public static Concrete.NameParameter cName(Object data, boolean explicit, Referable referable) {
+    return new Concrete.NameParameter(data, explicit, referable);
   }
 
   public static Concrete.TypeParameter cTypeArg(boolean explicit, Concrete.Expression type) {

--- a/base/src/main/java/org/arend/term/prettyprint/ToAbstractVisitor.java
+++ b/base/src/main/java/org/arend/term/prettyprint/ToAbstractVisitor.java
@@ -587,7 +587,7 @@ public class ToAbstractVisitor extends BaseExpressionVisitor<Void, Concrete.Expr
         args.add(cTypeArg(link.isExplicit(), link.getTypeExpr().accept(this, null)));
       } else {
         referableList.add(referable);
-        args.add(cTele(link.isExplicit(), new ArrayList<>(referableList), link.getTypeExpr().accept(this, null)));
+        args.add(cTele(link, link.isExplicit(), new ArrayList<>(referableList), link.getTypeExpr().accept(this, null)));
         referableList.clear();
       }
     }

--- a/base/src/main/java/org/arend/typechecking/error/local/GoalDataHolder.java
+++ b/base/src/main/java/org/arend/typechecking/error/local/GoalDataHolder.java
@@ -5,6 +5,7 @@ import org.arend.core.context.binding.EvaluatingBinding;
 import org.arend.core.expr.Expression;
 import org.arend.core.subst.ExprSubstitution;
 import org.arend.ext.concrete.ConcreteSourceNode;
+import org.arend.ext.core.ops.NormalizationMode;
 import org.arend.ext.error.TypecheckingError;
 import org.arend.ext.prettyprinting.PrettyPrinterConfig;
 import org.arend.ext.prettyprinting.doc.Doc;
@@ -34,9 +35,9 @@ public class GoalDataHolder extends TypecheckingError {
                         @Nullable Expression expectedType) {
     super(level, message, cause);
     this.typecheckingContext = typecheckingContext;
-    this.bindingTypes = bindingTypes;
+    this.bindingTypes = normalizeValues(bindingTypes);
     this.substitution = calculateSubstitution(typecheckingContext);
-    this.expectedType = expectedType == null ? null : expectedType.subst(substitution);
+    this.expectedType = expectedType == null ? null : expectedType.subst(substitution).normalize(NormalizationMode.RNF);
   }
 
   @NotNull
@@ -87,5 +88,13 @@ public class GoalDataHolder extends TypecheckingError {
   @Override
   public boolean hasExpressions() {
     return true;
+  }
+
+  private Map<Binding, Expression> normalizeValues(Map<Binding, Expression> baseMap) {
+    Map<Binding, Expression> newMap = new LinkedHashMap<>(baseMap.size());
+    for (Map.Entry<Binding, Expression> entry : baseMap.entrySet()) {
+      newMap.put(entry.getKey(), entry.getValue().normalize(NormalizationMode.RNF));
+    }
+    return newMap;
   }
 }


### PR DESCRIPTION
This PR adds more functionality to the pretty printer, allowing to print more information only for certain subexpressions rather than for the entire concrete at once.